### PR TITLE
Plugin settings ✨

### DIFF
--- a/src/app/helpers/constants.ts
+++ b/src/app/helpers/constants.ts
@@ -1,0 +1,3 @@
+
+// the constant for the name of the install lockfile
+export const pluginInstalledLockFileName = 'overlayed-install.lock'

--- a/src/app/helpers/serialization.tsx
+++ b/src/app/helpers/serialization.tsx
@@ -1,5 +1,11 @@
 import { remote } from 'electron'
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs'
+import moment from 'moment'
+import os from 'os'
+import { join } from 'path'
 import React from 'react'
+import { IInstalledPlugin, IInstallNeededPlugin, IPluginProperties } from '../plugin/IPlugin'
+import { pluginInstalledLockFileName } from './constants'
 
 // need to use the remote require because electron-settings asks us to (see wiki)
 const settings = remote.require('electron-settings')
@@ -15,7 +21,7 @@ export interface IManipulateSettingsProps<TSettings = {}> {
 // HOC that creates a component that injects settings via props
 // 
 // TODO(bengreenier): the typing on the return isn't coming through :(
-export const withSettings = <Q extends object, P extends IManipulateSettingsProps<Q>>(Comp : React.ComponentType<P>) => {
+export const withSettings = <Q extends object, P extends IManipulateSettingsProps<Q>>(Comp : React.ComponentType<P>, compSettings: any) => {
   return class WithSettings extends React.Component<P & IWithSettingsProps, any> {
 
     constructor(props : P & IWithSettingsProps) {
@@ -28,14 +34,88 @@ export const withSettings = <Q extends object, P extends IManipulateSettingsProp
       const { settingsKey, ...props } = this.props as IWithSettingsProps
 
       // extend props with settings
-      const data = {...props, ...settings.get(settingsKey)}
+      const data = {...props, ...compSettings}
 
       // render the component with data as it's given props (so it contains settings)
       return <Comp updateSettings={this.updateSettings} {...data} />
     }
 
     private updateSettings(data : IManipulateSettingsProps<Q>) {
-      settings.set(this.props.settingsKey, data)
+      settings.set(this.props.settingsKey, data, { prettify: true })
     }
   }
+}
+
+// Gets all plugins
+export const getPlugins = () => {
+  const rootSettings = settings.getAll()
+
+  // load internals
+  const internalPlugins = loadPlugins(`${__dirname}/../plugin`, rootSettings)
+
+  // load user
+  const userPlugins = loadPlugins(join(os.homedir(), '.overlayed'), rootSettings)
+
+  return internalPlugins.concat(userPlugins)
+}
+
+const isDirectory = (source : string) => lstatSync(source).isDirectory()
+const getDirectories = (source : string)  =>
+  readdirSync(source).map((name : string) => join(source, name)).filter(isDirectory)
+
+const loadPlugins = (dir : string, rootSettings : any) => {
+  // if the dir is no good, gtfo
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  // enumerating internal plugin directories
+  return getDirectories(dir).map((pluginDir) => {
+    const jsonData = readFileSync(join(pluginDir, 'package.json')).toString()
+    const pkg = JSON.parse(jsonData)
+    const componentPath = join(pluginDir, pkg.main as string)
+
+    // by default we install if there's deps
+    let needsInstall = pkg.dependencies && Object.keys(pkg.dependencies).length > 0 ? true : false
+
+    // however, if there's an install lockfile
+    const installLockFilePath = join(pluginDir, pluginInstalledLockFileName)
+    if (existsSync(installLockFilePath)) {
+      const installLockFile = readFileSync(installLockFilePath).toString()
+
+      // we check if it's been installed in the last day
+      // if it has we don't install again
+      if (installLockFile) {
+        const installDate = moment(installLockFile)
+
+        // TODO(begreenier): support force install
+        if (installDate.add(1, 'day').isBefore(moment())) {
+          needsInstall = true
+        } else {
+          needsInstall = false
+        }
+      }
+    }
+
+    // generate plugin structure
+    const plugin : IPluginProperties = {
+      diskPath: pluginDir,
+      name: pkg.name,
+      requiresInstall: needsInstall,
+      settings: rootSettings[pkg.name] || {},
+      version: pkg.version,
+    }
+
+    // if we need deps installed, we can't load the plugin yet, so we don't
+    // we return a variant of IPluginProperties
+    if (plugin.requiresInstall) {
+      return {...plugin, ...{
+        component: componentPath
+      }} as IInstallNeededPlugin
+    } else {
+      return {...plugin, ...{
+        component: require(componentPath).default as React.ComponentType<any>
+      }} as IInstalledPlugin
+    }
+  })
 }

--- a/src/app/helpers/serialization.tsx
+++ b/src/app/helpers/serialization.tsx
@@ -21,7 +21,7 @@ export interface IManipulateSettingsProps<TSettings = {}> {
 // HOC that creates a component that injects settings via props
 // 
 // TODO(bengreenier): the typing on the return isn't coming through :(
-export const withSettings = <Q extends object, P extends IManipulateSettingsProps<Q>>(Comp : React.ComponentType<P>, compSettings: any) => {
+export const withSettings = <Q extends object, P extends IManipulateSettingsProps<Q>>(Comp : React.ComponentType<P>, compSettings ?: any) => {
   return class WithSettings extends React.Component<P & IWithSettingsProps, any> {
 
     constructor(props : P & IWithSettingsProps) {
@@ -34,7 +34,7 @@ export const withSettings = <Q extends object, P extends IManipulateSettingsProp
       const { settingsKey, ...props } = this.props as IWithSettingsProps
 
       // extend props with settings
-      const data = {...props, ...compSettings}
+      const data = {...props, ...(compSettings || settings.get(settingsKey))}
 
       // render the component with data as it's given props (so it contains settings)
       return <Comp updateSettings={this.updateSettings} {...data} />

--- a/src/app/helpers/serialization.tsx
+++ b/src/app/helpers/serialization.tsx
@@ -1,0 +1,26 @@
+import { remote } from 'electron'
+import React from 'react'
+
+// need to use the remote require because electron-settings asks us to (see wiki)
+const settings = remote.require('electron-settings')
+
+interface IWithSettingsProps {
+  settingsKey : string
+}
+
+// HOC that creates a component that injects settings via props
+// 
+// TODO(bengreenier): the typing on the return isn't coming through :(
+export const withSettings = <P extends object>(Comp : React.ComponentType<P>) => {
+  return class WithSettings extends React.Component<P & IWithSettingsProps, any> {
+    public render() {
+      const { settingsKey, ...props } = this.props as IWithSettingsProps
+
+      // extend props with settings
+      const data = {...props, ...settings.get(settingsKey)}
+
+      // render the component with data as it's given props (so it contains settings)
+      return <Comp {...data} />
+    }
+  }
+}

--- a/src/app/helpers/serialization.tsx
+++ b/src/app/helpers/serialization.tsx
@@ -8,11 +8,22 @@ interface IWithSettingsProps {
   settingsKey : string
 }
 
+export interface IManipulateSettingsProps<TSettings = {}> {
+  updateSettings : (data : TSettings) => void
+}
+
 // HOC that creates a component that injects settings via props
 // 
 // TODO(bengreenier): the typing on the return isn't coming through :(
-export const withSettings = <P extends object>(Comp : React.ComponentType<P>) => {
+export const withSettings = <Q extends object, P extends IManipulateSettingsProps<Q>>(Comp : React.ComponentType<P>) => {
   return class WithSettings extends React.Component<P & IWithSettingsProps, any> {
+
+    constructor(props : P & IWithSettingsProps) {
+      super(props)
+      
+      this.updateSettings = this.updateSettings.bind(this)
+    }
+
     public render() {
       const { settingsKey, ...props } = this.props as IWithSettingsProps
 
@@ -20,7 +31,11 @@ export const withSettings = <P extends object>(Comp : React.ComponentType<P>) =>
       const data = {...props, ...settings.get(settingsKey)}
 
       // render the component with data as it's given props (so it contains settings)
-      return <Comp {...data} />
+      return <Comp updateSettings={this.updateSettings} {...data} />
+    }
+
+    private updateSettings(data : IManipulateSettingsProps<Q>) {
+      settings.set(this.props.settingsKey, data)
     }
   }
 }

--- a/src/app/main/Plugin.tsx
+++ b/src/app/main/Plugin.tsx
@@ -1,0 +1,25 @@
+import React, { CSSProperties } from 'react'
+import { withSettings } from '../helpers/serialization'
+import { IInstalledPlugin } from '../plugin/IPlugin'
+
+interface IPluginProps {
+  plugin : IInstalledPlugin
+}
+
+// the base styles for a plugin
+//
+// note: this is exported because of RGL issues
+// https://github.com/STRML/react-grid-layout/issues/397
+export const pluginStyles = {
+  backgroundColor: 'green',
+} as CSSProperties
+
+export class Plugin extends React.Component<IPluginProps, any> {
+  public render() {
+    const PluginWithSettings = withSettings(this.props.plugin.component)
+
+    return (
+      <PluginWithSettings settingsKey={this.props.plugin.name} />
+    )
+  }
+}

--- a/src/app/main/Plugin.tsx
+++ b/src/app/main/Plugin.tsx
@@ -16,7 +16,7 @@ export const pluginStyles = {
 
 export class Plugin extends React.Component<IPluginProps, any> {
   public render() {
-    const PluginWithSettings = withSettings(this.props.plugin.component)
+    const PluginWithSettings = withSettings(this.props.plugin.component, this.props.plugin.settings)
 
     return (
       <PluginWithSettings settingsKey={this.props.plugin.name} />

--- a/src/app/main/main.tsx
+++ b/src/app/main/main.tsx
@@ -2,7 +2,7 @@ import os from 'os'
 import { join } from 'path'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { PluginGrid } from '../helpers/PluginGrid'
+import { PluginGrid } from './PluginGrid'
 
 // the constant user plugin dir
 const userPluginDir = join(os.homedir(), '.overlayed')

--- a/src/app/main/main.tsx
+++ b/src/app/main/main.tsx
@@ -2,17 +2,17 @@ import os from 'os'
 import { join } from 'path'
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { withSettings } from '../helpers/serialization'
 import { PluginGrid } from './PluginGrid'
 
-// the constant user plugin dir
-const userPluginDir = join(os.homedir(), '.overlayed')
+const PluginGridWithSettings = withSettings(PluginGrid as React.ComponentType<any>)
 
 /**
  * Top Level react component
  */
 class MainApp extends React.Component<any, any> {
   public render() {
-    return <PluginGrid userPluginDir={userPluginDir} />
+    return <PluginGridWithSettings settingsKey={'overlayed.grid'} />
   }
 }
 

--- a/src/app/plugin/Clock/ClockPlugin.tsx
+++ b/src/app/plugin/Clock/ClockPlugin.tsx
@@ -1,5 +1,12 @@
 import React from "react"
 
+interface IProps {
+  /**
+   * Visualized locale
+   */
+  locale ?: string
+}
+
 interface IState {
   date : Date
 }
@@ -7,10 +14,14 @@ interface IState {
 /**
  * Example stateful plugin
  */
-export default class ClockPlugin extends React.Component<any, IState> {
+export default class ClockPlugin extends React.Component<IProps, IState> {
+  public static defaultProps : IProps = {
+    locale: 'en-US'
+  }
+
   private clockInterval ?: number
 
-  constructor(props : any) {
+  constructor(props : IProps) {
     super(props)
 
     this.state = {
@@ -29,7 +40,7 @@ export default class ClockPlugin extends React.Component<any, IState> {
   }
 
   public render() {
-    return <h1>{this.state.date.toLocaleTimeString()}</h1>
+    return <h1>{this.state.date.toLocaleTimeString(this.props.locale)}</h1>
   }
 
   private tick() {

--- a/src/app/plugin/Clock/ClockPlugin.tsx
+++ b/src/app/plugin/Clock/ClockPlugin.tsx
@@ -12,7 +12,7 @@ interface IState {
 }
 
 /**
- * Example stateful plugin
+ * Example settings-consuming plugin
  */
 export default class ClockPlugin extends React.Component<IProps, IState> {
   public static defaultProps : IProps = {

--- a/src/app/plugin/IPlugin.ts
+++ b/src/app/plugin/IPlugin.ts
@@ -19,7 +19,12 @@ export interface IPluginProperties {
   /**
    * Does the plugin require an `npm install`
    */
-  requiresInstall: boolean
+  requiresInstall: boolean,
+
+  /**
+   * The object containing plugin settings
+   */
+  settings: any
 }
 
 /**

--- a/src/app/plugin/IPlugin.ts
+++ b/src/app/plugin/IPlugin.ts
@@ -31,7 +31,7 @@ export interface IInstalledPlugin extends IPluginProperties{
   /**
    * The actual react component
    */
-  component: React.Component<any, any>
+  component: React.ComponentType<any>
 }
 
 export interface IInstallNeededPlugin extends IPluginProperties {

--- a/src/app/plugin/Incrementer/IncrementerPlugin.tsx
+++ b/src/app/plugin/Incrementer/IncrementerPlugin.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import { IManipulateSettingsProps } from "../../helpers/serialization"
+
+interface ISettings {
+  value: number
+}
+
+interface IProps extends IManipulateSettingsProps<ISettings>, ISettings {
+
+}
+
+/**
+ * Example plugin with update-setting support
+ */
+export default class RangeMathPlugin extends React.Component<IProps, ISettings> {
+  public static defaultProps : Partial<IProps> = {
+    value: 0
+  }
+
+  private tickInterval ?: number;
+
+  constructor(props : IProps) {
+    super(props)
+
+    this.state = {
+      value: this.props.value
+    }
+  }
+
+  public componentDidMount() {
+    this.tickInterval = setInterval(this.tick.bind(this), 5000)
+  }
+
+  public componentWillUnmount() {
+    if (this.tickInterval) {
+      clearInterval(this.tickInterval)
+    }
+
+    // we can do this when https://github.com/bengreenier/overlayed/issues/17 is resolved
+    // 
+    // this.props.updateSettings(this.state)
+  }
+
+  public render() {
+    return <h1>{this.state.value}</h1>
+  }
+
+  private tick() {
+    this.setState({
+      value: this.state.value + 1
+    })
+    
+    // write this out each tick
+    this.props.updateSettings(this.state)
+  }
+}

--- a/src/app/plugin/Incrementer/package.json
+++ b/src/app/plugin/Incrementer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "incrementer",
+  "version": "0.0.1",
+  "main": "IncrementerPlugin.js"
+}

--- a/src/app/plugin/Muxy/MuxyAlertsPlugin.tsx
+++ b/src/app/plugin/Muxy/MuxyAlertsPlugin.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React from 'react'
 
 export interface IMuxyAlertConfiguration {
   /**


### PR DESCRIPTION
This will add per-plugin settings support using a HOC react component to inject data into component props when the overlay is loaded.

_With less react words, that means:_ there's a function that injects the props we pass to components when we create them by reading from the settings file first. 😅 

It does that by reading the `name` (of the overlay, as defined by it's `package.json`) and checking settings for a key with that value. If such a key exists, the object will be treated as the overlay's "settings" and passed in as `props`.

This PR needs to address these before merge:

- [x] #3 
- [x] #5 
- [x] #15



