### PR TITLE
support react in dependencies 📦

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ These will (in order): install dependencies, build the project, start the applic
 + Run `npm init` or manually create a `package.json` file
 + Ensure `package.json` contains `name`, `version`, and `main`
 + Ensure main points to a `.js` file that has a [default export](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export#Using_the_default_export) (or `module.exports.default = YourClass`)
-+ Ensure you do not include `react` in your dependencies (it's implicit) - for development, you may choose to include it in `devDependencies`
 + Profit! Overlayed will attempt to load your plugin on start
 
 For example:

--- a/src/app/helpers/serialization.tsx
+++ b/src/app/helpers/serialization.tsx
@@ -76,7 +76,8 @@ const loadPlugins = (dir : string, rootSettings : any) => {
     const componentPath = join(pluginDir, pkg.main as string)
 
     // by default we install if there's deps
-    let needsInstall = pkg.dependencies && Object.keys(pkg.dependencies).length > 0 ? true : false
+    // (we allow react as a dep)
+    let needsInstall = pkg.dependencies && Object.keys(pkg.dependencies).filter(k => k.toLowerCase() !== 'react').length > 0 ? true : false
 
     // however, if there's an install lockfile
     const installLockFilePath = join(pluginDir, pluginInstalledLockFileName)

--- a/src/app/plugin/Clock/package.json
+++ b/src/app/plugin/Clock/package.json
@@ -1,5 +1,8 @@
 {
   "name": "clock",
   "version": "0.0.1",
-  "main": "ClockPlugin.js"
+  "main": "ClockPlugin.js",
+  "dependencies": {
+    "react": "^16.4.2"
+  }
 }

--- a/src/app/plugin/RangeMath/package.json
+++ b/src/app/plugin/RangeMath/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "main": "RangeMathPlugin.js",
   "dependencies": {
-    "range-fit": "^0.1.1"
+    "range-fit": "^0.1.1",
+    "react": "^16.4.2"
   }
 }


### PR DESCRIPTION
fix #9 - adds support for react in `dependencies` - this no longer triggers an `install` when we load up the plugin (so your plugin can reference react, and still load quick)