### PR TITLE
Fixed failing build on macOS 🐛

### DIFF
--- a/.bin/build-static.js
+++ b/.bin/build-static.js
@@ -1,0 +1,13 @@
+const copy = require('recursive-copy')
+
+copy(__dirname + '/../src', 'dist', {
+  overwrite: true,
+  filter: ['!dist**', '!node_modules**', '**/*.html', '**/package.json']
+}).then(() => {
+  // success, exit 0
+  process.exit(0)
+}, (err) => {
+  // log error, exit failure
+  console.error(err)
+  process.exit(-1)
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean & tsc & npm run build-static",
-    "build-static": "echo require('recursive-copy')(__dirname + '/src', 'dist', {filter: ['!dist**', '!node_modules**', '**/*.html', '**/package.json']})  | node",
+    "build-static": "echo \"require('recursive-copy')(__dirname + '/src', 'dist', {filter: ['!dist**', '!node_modules**', '**/*.html', '**/package.json']})\"  | node",
     "start": "electron .",
     "start-debug": "electron --inspect=5858 .",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean & tsc & npm run build-static",
+    "build": "npm run clean && tsc && npm run build-static",
     "build-static": "echo \"require('recursive-copy')(__dirname + '/src', 'dist', {filter: ['!dist**', '!node_modules**', '**/*.html', '**/package.json']})\"  | node",
     "start": "electron .",
     "start-debug": "electron --inspect=5858 .",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc && npm run build-static",
-    "build-static": "echo \"require('recursive-copy')(__dirname + '/src', 'dist', {filter: ['!dist**', '!node_modules**', '**/*.html', '**/package.json']})\"  | node",
+    "build-static": "node .bin/build-static.js",
     "start": "electron .",
     "start-debug": "electron --inspect=5858 .",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Apparently, the `echo` command doesn't like parentheses, if they are not wrapped in quotes. Mac users can now happily build again! 🎉

Edit: I just figured out that builds sometimes fail because the build steps run in parallel. I've tested it - obviously - on macOS but I don't know if this breaks something under windows... ¯\\\_(ツ)\_/¯

Fixes #18 