### PR TITLE
Error tooltips and logging 🤕 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -358,7 +358,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -486,6 +486,11 @@
         "semver": "^5.4.1",
         "sumchecker": "^2.0.2"
       }
+    },
+    "electron-log": {
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-2.2.17.tgz",
+      "integrity": "sha512-v+Af5W5z99ehhaLOfE9eTSXUwjzh2wFlQjz51dvkZ6ZIrET6OB/zAZPvsuwT6tm3t5x+M1r+Ed3U3xtPZYAyuQ=="
     },
     "electron-settings": {
       "version": "3.2.0",
@@ -799,7 +804,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -928,7 +933,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1341,7 +1346,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
         "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/bengreenier/overlayed#readme",
   "dependencies": {
     "electron": "^3.0.0",
+    "electron-log": "^2.2.17",
     "electron-settings": "^3.2.0",
     "enpeem": "^2.2.0",
     "moment": "^2.22.2",

--- a/src/app/helpers/serialization.tsx
+++ b/src/app/helpers/serialization.tsx
@@ -1,4 +1,5 @@
 import { remote } from 'electron'
+import log from 'electron-log'
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs'
 import moment from 'moment'
 import os from 'os'
@@ -42,6 +43,7 @@ export const withSettings = <Q extends object, P extends IManipulateSettingsProp
 
     private updateSettings(data : IManipulateSettingsProps<Q>) {
       settings.set(this.props.settingsKey, data, { prettify: true })
+      log.verbose(`updating settings: ${this.props.settingsKey} = ${JSON.stringify(data)}`)
     }
   }
 }

--- a/src/app/main/ErrorBoundry.tsx
+++ b/src/app/main/ErrorBoundry.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+
+export class ErrorBoundary extends React.Component<{onError: (err : Error) => void}, {hasError: boolean}> {
+  constructor(props : any) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  public componentDidCatch(error : Error) {
+    this.setState({ hasError: true })
+    this.props.onError(error)
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return <h1>Failed to Render</h1>
+    }
+
+    return this.props.children
+  }
+}

--- a/src/app/main/Plugin.tsx
+++ b/src/app/main/Plugin.tsx
@@ -1,3 +1,4 @@
+import log from 'electron-log'
 import open from 'open'
 import React, { CSSProperties } from 'react'
 import { withSettings } from '../helpers/serialization'
@@ -42,6 +43,7 @@ export class Plugin extends React.Component<IPluginProps, any> {
     if (e.target) {
       const uri = (e.target as HTMLElement).getAttribute('data-open')
       if (uri) {
+        log.info(`plugin label clicked: opening ${uri}`)
         open(uri)
       }
     }

--- a/src/app/main/PluginGrid.tsx
+++ b/src/app/main/PluginGrid.tsx
@@ -130,7 +130,7 @@ export class PluginGrid extends React.Component<IPluginGridProps, IState> {
         plugins: this.state.plugins.concat(installedPlugins)
       })
     }, (error) => {
-      log.error(`failed installation: ${error}`)
+      log.error(`failed installation, ${error}`)
     })
   }
 

--- a/src/app/main/PluginGrid.tsx
+++ b/src/app/main/PluginGrid.tsx
@@ -1,3 +1,4 @@
+import log from 'electron-log'
 import enpeem from 'enpeem'
 import { readFileSync, writeFileSync } from 'fs'
 import moment from 'moment'
@@ -111,10 +112,14 @@ export class PluginGrid extends React.Component<IPluginGridProps, IState> {
     const noInstallNeeded = plugins.filter(p => !p.requiresInstall) as IInstalledPlugin[]
     const installNeeded = plugins.filter(p => p.requiresInstall) as IInstallNeededPlugin[]
     
+    log.info(`starting load for [${noInstallNeeded.map(e => e.name).join(',')}]`)
+
     // load installed plugins
     this.setState({
       plugins: noInstallNeeded
     })
+
+    log.info(`starting install for [${installNeeded.map(e => e.name).join(',')}]`)
 
     // install the uninstalled plugins
     Promise.all(this.installPlugins(installNeeded)).then((installedPlugins) => {
@@ -122,6 +127,8 @@ export class PluginGrid extends React.Component<IPluginGridProps, IState> {
       this.setState({
         plugins: this.state.plugins.concat(installedPlugins)
       })
+    }, (error) => {
+      log.error(`failed installation: ${error}`)
     })
   }
 

--- a/src/app/main/main.tsx
+++ b/src/app/main/main.tsx
@@ -1,9 +1,8 @@
 import { ipcRenderer } from 'electron'
-import os from 'os'
-import { join } from 'path'
+import log from 'electron-log'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { IPCMessageNames } from '../../ipc/IPCMessageNames';
+import { IPCMessageNames } from '../../ipc/IPCMessageNames'
 import { withSettings } from '../helpers/serialization'
 import { PluginGrid } from './PluginGrid'
 
@@ -56,8 +55,12 @@ ReactDOM.render(React.createElement(MainApp, null), topLevelNode)
 
 // listen for shutdown
 ipcRenderer.on(IPCMessageNames.RequestShutdown, () => {
+  log.info('starting renderer shutdown')
+
   // wait for the dom changes to actually occur
   const obs = new MutationObserver(() => {
+    log.info('renderer nodes unmounted, finishing shutdown')
+
     // report back that we're safe to unload now
     ipcRenderer.sendSync(IPCMessageNames.AllowShutdown)
   })

--- a/src/electron/Bootstrap.ts
+++ b/src/electron/Bootstrap.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, Menu, MenuItem, nativeImage, Tray } from "electron"
-import { log } from 'electron-log'
+import log from 'electron-log'
 import settings from "electron-settings"
 import os from "os"
 import path from "path"
@@ -13,6 +13,15 @@ export class Bootstrap {
   public tray : Tray
 
   constructor() {
+    // setup ipc commands
+
+    // support showing tooltips
+    ipcMain.on(IPCMessageNames.ShowTooltip, (e : Event, tooltipOpts : Electron.DisplayBalloonOptions) => {
+      log.info(`showing tooltip ${tooltipOpts.title}`)
+
+      this.tray.displayBalloon(tooltipOpts)
+    })
+
     // setup the tray
     this.tray = new Tray(this.getTrayIcon())
 
@@ -27,7 +36,6 @@ export class Bootstrap {
     this.compositor = new CompositeWindow(this.getCompositorSettings())
 
     this.compositor.loadFile(`${__dirname}/../app/main/main.html`)
-    
 
     let isShuttingDown = false
     this.compositor.on('close', (e) => {
@@ -59,7 +67,7 @@ export class Bootstrap {
         { prettify: true })
     })
 
-    log('completed electron bootstrapping')
+    log.info('completed electron bootstrapping')
   }
 
   private getCompositorSettings() {

--- a/src/electron/Bootstrap.ts
+++ b/src/electron/Bootstrap.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, Menu, MenuItem, nativeImage, Tray } from "electron"
-import log from 'electron-log'
+import log from "electron-log"
 import settings from "electron-settings"
 import os from "os"
 import path from "path"

--- a/src/electron/Bootstrap.ts
+++ b/src/electron/Bootstrap.ts
@@ -1,0 +1,138 @@
+import { app, ipcMain, Menu, MenuItem, nativeImage, Tray } from "electron"
+import { log } from 'electron-log'
+import settings from "electron-settings"
+import os from "os"
+import path from "path"
+import { IPCMessageNames } from "../ipc/IPCMessageNames"
+import { CompositeWindow } from "./CompositeWindow"
+
+const windowSettingsKey = 'overlayed.window'
+
+export class Bootstrap {
+  public compositor : CompositeWindow
+  public tray : Tray
+
+  constructor() {
+    // setup the tray
+    this.tray = new Tray(this.getTrayIcon())
+
+    this.tray.setContextMenu(this.buildTrayMenu())
+    this.tray.setToolTip('Overlayed')
+
+    this.tray.on('click', () => {
+      this.tray.popUpContextMenu()
+    })
+
+    // setup the compositor
+    this.compositor = new CompositeWindow(this.getCompositorSettings())
+
+    this.compositor.loadFile(`${__dirname}/../app/main/main.html`)
+    
+
+    let isShuttingDown = false
+    this.compositor.on('close', (e) => {
+      if (!isShuttingDown) {
+        e.preventDefault()
+    
+        isShuttingDown = true
+        
+        // if we aren't shutdown in 5s, force it
+        setTimeout(() => {
+          this.compositor.close()
+        }, 5000)
+  
+        // listen for react to complete
+        ipcMain.on(IPCMessageNames.AllowShutdown, () => {
+          this.compositor.close()
+        })
+  
+        // ask react to shutdown
+        this.compositor.webContents.send(IPCMessageNames.RequestShutdown)
+      }
+    })
+
+    // save state when we're closing
+    this.compositor.on('close', () => {
+      // save out window settings
+      settings.set(windowSettingsKey,
+        this.compositor.getBounds() as any,
+        { prettify: true })
+    })
+
+    log('completed electron bootstrapping')
+  }
+
+  private getCompositorSettings() {
+    return settings.get(windowSettingsKey, {
+      height: 480,
+      width: 680,
+      x: 0,
+      y: 0,
+    }) as {x: number, y: number, width: number, height: number}
+  }
+
+  private buildTrayMenu() {
+    const mainTrayMenu = new Menu()
+    const devTrayMenu = new Menu()
+
+    mainTrayMenu.append(new MenuItem({
+      click: () => {
+        this.compositor.toggleWindowInteractivity()
+      },
+      label: 'Toggle Edit',
+    }))
+
+    mainTrayMenu.append(new MenuItem({
+      label: 'Developer',
+      submenu: devTrayMenu,
+    }))
+
+    mainTrayMenu.append(new MenuItem({
+      click: () => {
+        app.quit()
+      },
+      label: 'Close',
+    }))
+
+    devTrayMenu.append(new MenuItem({
+      click: () => {
+        this.compositor.toggleDevTools()
+      },
+      label: 'Toggle Tools',
+    }))
+
+    devTrayMenu.append(new MenuItem({
+      click: () => {
+        this.compositor.reload()
+      },
+      label: 'Force Reload',
+    }))
+
+    return mainTrayMenu
+  }
+
+  private getTrayIcon() {
+    const getNativeImage = (filename: string) =>
+      nativeImage.createFromPath(path.join(__dirname, 'assets/images', filename))
+  
+    // Load correct icon depending on the current platform.
+    switch (os.platform()) {
+  
+      // Use the 16x16 (tray.png) and 32x32 (tray@2x.png) versions for macOS.
+      // The system chosses the correct file automatically.
+      // We also need to set it as a template image so macOS can colour it depending on the current system theme.
+      case 'darwin':
+        const image = getNativeImage('tray.png')
+        image.setTemplateImage(true)
+        return image
+      
+      // Use the ICO file for Windows.
+      case 'win32':
+        return getNativeImage('tray.ico')
+  
+      // Use the 'raw' PNG file for all other platforms.
+      default:
+        return getNativeImage('trayFull.png')
+    }
+  }
+}

--- a/src/electron/CompositeWindow.ts
+++ b/src/electron/CompositeWindow.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, BrowserWindowConstructorOptions } from "electron"
-import { log } from "electron-log"
+import log from "electron-log"
 import { IPCMessageNames } from "../ipc/IPCMessageNames"
 
 /**
@@ -31,7 +31,7 @@ export class CompositeWindow extends BrowserWindow {
 
     // notify react side
     this.webContents.send(IPCMessageNames.ToggleEditMode, this.isInteractive)
-    log('toggled compositor interactivity')
+    log.info('toggled compositor interactivity')
   }
 
   /**
@@ -39,6 +39,6 @@ export class CompositeWindow extends BrowserWindow {
    */
   public toggleDevTools() {
     this.webContents.toggleDevTools()
-    log('toggled compositor DevTools')
+    log.info('toggled compositor DevTools')
   }
 }

--- a/src/electron/CompositeWindow.ts
+++ b/src/electron/CompositeWindow.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, BrowserWindowConstructorOptions } from "electron"
-import { IPCMessageNames } from "../ipc/IPCMessageNames";
+import { log } from "electron-log"
+import { IPCMessageNames } from "../ipc/IPCMessageNames"
 
 /**
  * Overlay style electron window
@@ -30,6 +31,7 @@ export class CompositeWindow extends BrowserWindow {
 
     // notify react side
     this.webContents.send(IPCMessageNames.ToggleEditMode, this.isInteractive)
+    log('toggled compositor interactivity')
   }
 
   /**
@@ -37,5 +39,6 @@ export class CompositeWindow extends BrowserWindow {
    */
   public toggleDevTools() {
     this.webContents.toggleDevTools()
+    log('toggled compositor DevTools')
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,150 +1,28 @@
-import { app, ipcMain, Menu, MenuItem, nativeImage, Tray } from 'electron'
-import settings from 'electron-settings'
-import { platform } from 'os'
-import path from 'path'
-import { CompositeWindow } from './electron/CompositeWindow'
-import { IPCMessageNames } from './ipc/IPCMessageNames';
+import { app } from 'electron'
+import log from 'electron-log'
+import { Bootstrap } from './electron/Bootstrap'
 
-let mainWindow : CompositeWindow
-let mainTray : Tray
+let bs : Bootstrap
 
-/**
- * Gets the correct icon for the system tray depending on the current platform.
- */
-const getTrayIcon = () => {
-  const getNativeImage = (filename: string) =>
-    nativeImage.createFromPath(path.join(__dirname, 'electron/assets/images', filename))
-
-  // Load correct icon depending on the current platform.
-  switch (platform()) {
-
-    // Use the 16x16 (tray.png) and 32x32 (tray@2x.png) versions for macOS.
-    // The system chosses the correct file automatically.
-    // We also need to set it as a template image so macOS can colour it depending on the current system theme.
-    case 'darwin':
-      const image = getNativeImage('tray.png')
-      image.setTemplateImage(true)
-      return image
-    
-    // Use the ICO file for Windows.
-    case 'win32':
-      return getNativeImage('tray.ico')
-
-    // Use the 'raw' PNG file for all other platforms.
-    default:
-      return getNativeImage('trayFull.png')
-  }
+// set the level to verbose if not production
+if (process.env.NODE_ENV !== 'production') {
+  log.transports.file.level = 'verbose'
 }
 
-
-// our window dimensions settings key path
-const windowDimsSettingsKey = 'overlayed.window'
-
 const allocMainWindow = () => {
-
-  // see if we have window settings, if so, use them
-  const windowDims = settings.get(windowDimsSettingsKey, {
-    height: 480,
-    width: 680,
-    x: 0,
-    y: 0,
-  }) as {x: number, y: number, width: number, height: number}
-
-  // create our window
-  mainWindow = new CompositeWindow(windowDims)
-  
-  // tell the window to load the entry point
-  mainWindow.loadFile(`${__dirname}/app/main/main.html`)
-
-  let isShuttingDown = false
-  mainWindow.on('close', (e) => {
-    if (!isShuttingDown) {
-      e.preventDefault()
-  
-      isShuttingDown = true
-      
-      // if we aren't shutdown in 5s, force it
-      setTimeout(() => {
-        mainWindow.close()
-      }, 5000)
-
-      // listen for react to complete
-      ipcMain.on(IPCMessageNames.AllowShutdown, () => {
-        mainWindow.close()
-      })
-
-      // ask react to shutdown
-      mainWindow.webContents.send(IPCMessageNames.RequestShutdown)
-    }
-  })
-
-  // save state when we're closing
-  mainWindow.on('close', () => {
-    // save out window settings
-    settings.set(windowDimsSettingsKey,
-      mainWindow.getBounds() as any,
-      { prettify: true });
-  })
+  bs = new Bootstrap()
 
   // cleanup when we're closed
-  mainWindow.on('closed', () => {
+  bs.compositor.on('closed', () => {
     // nuke the window
-    (mainWindow as any) = null
+    (bs as any) = null
   })
-
-  // create our tray system
-  mainTray = new Tray(getTrayIcon())
-  mainTray.setToolTip('Overlayed')
-
-  mainTray.on('click', () => {
-    mainTray.popUpContextMenu()
-  })
-
-  // create the menus we'll add to the tray system
-  const mainTrayMenu = new Menu()
-  const devTrayMenu = new Menu()
-
-  mainTrayMenu.append(new MenuItem({
-    click: () => {
-      mainWindow.toggleWindowInteractivity()
-    },
-    label: 'Toggle Edit',
-  }))
-
-  mainTrayMenu.append(new MenuItem({
-    label: 'Developer',
-    submenu: devTrayMenu,
-  }))
-
-  mainTrayMenu.append(new MenuItem({
-    click: () => {
-      app.quit()
-    },
-    label: 'Close',
-  }))
-
-  devTrayMenu.append(new MenuItem({
-    click: () => {
-      mainWindow.toggleDevTools()
-    },
-    label: 'Toggle Tools'
-  }))
-
-  devTrayMenu.append(new MenuItem({
-    click: () => {
-      mainWindow.reload()
-    },
-    label: 'Force Reload'
-  }))
-
-  // setup the tray menus
-  mainTray.setContextMenu(mainTrayMenu)
 }
 
 // app handlers to get things going when electron starts
 app.on('ready', allocMainWindow)
 app.on('activate', () => {
-  if (mainWindow === null) {
+  if (bs === null) {
     allocMainWindow()
   }
 })

--- a/src/ipc/IPCMessageNames.ts
+++ b/src/ipc/IPCMessageNames.ts
@@ -1,5 +1,6 @@
 export enum IPCMessageNames {
   RequestShutdown = 'RequestShutdown',
   AllowShutdown = 'AllowShutdown',
-  ToggleEditMode = 'ToggleEditMode'
+  ToggleEditMode = 'ToggleEditMode',
+  ShowTooltip = 'ShowTooltip'
 }


### PR DESCRIPTION
This adds all those fancy debugging and safety features you've been looking for! ✨ 

+ Handle plugins that fail to load (`require('./path/to/plugin')` fails)
+ Handle plugins that fail to render (`React.createElement(Plugin)` fails)
+ Log critical events
+ Default log level to `verbose` when `NODE_ENV !== 'production'`
+ fixes #7 

The logging uses [electron-log](https://www.npmjs.com/package/electron-log) which writes to:

    on Linux: ~/.config/<app name>/log.log
    on OS X: ~/Library/Logs/<app name>/log.log
    on Windows: %USERPROFILE%\AppData\Roaming\<app name>\log.log

Plugin failures are communicated using the [Tray.displayBalloon()](https://electronjs.org/docs/api/tray#traydisplayballoonoptions-windows) electron api, as well as being written to the log.

Examples:

```
showing tooltip Plugin Render Error
[2018-10-02 10:52:38.229] [error] Failed to render clock located at V:\vs_workspace\overlayed\dist\app\plugin\Clock

showing tooltip Plugin Load Error
[2018-10-02 10:46:26.621] [error] Failed to load clock from V:\vs_workspace\overlayed\dist\app\plugin\Clock
```
