### PR TITLE
hotfix: no layout data on start 😨 

### DIFF
--- a/src/app/main/PluginGrid.tsx
+++ b/src/app/main/PluginGrid.tsx
@@ -36,7 +36,7 @@ export class PluginGrid extends React.Component<IPluginGridProps, IState> {
       editStyles: this.props.editStyles || {
         backgroundColor: 'rgba(51, 138, 46, 0.6)'
       },
-      layout: this.props.layout,
+      layout: this.props.layout || [],
       plugins: []
     }
 


### PR DESCRIPTION
Fixes an issue that can occur when there is no layout data present in the configuration for the system, but you startup for the first time.

__Issue: `this.state.layout` is `undefined` in the `PluginGrid`.__
__Solution: Default to an empty layout array (no data) on start.__

🥇 